### PR TITLE
Switch ace build from default to noconflict

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,1 @@
-export const ACE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.js';
+export const ACE_CDN = 'https://cdn.jsdelivr.net/npm/ace-builds@1.2.2/src-noconflict/ace.js';


### PR DESCRIPTION
Ace editor v1.2 overrides `window.require()` which cause some issue with application build with webpack. Switching to the build noconflict doesn't apply the override and make ace `require()` available under `window.ace.require()`

Repo with all available builds: https://github.com/ajaxorg/ace-builds